### PR TITLE
Batch requests

### DIFF
--- a/event-indexer/package-lock.json
+++ b/event-indexer/package-lock.json
@@ -15,6 +15,7 @@
         "eth-ens-namehash": "^2.0.8",
         "jayson": "^3.4.4",
         "js-conflux-sdk": "^1.5.13",
+        "morgan": "^1.10.0",
         "mysql2": "^2.2.5",
         "underscore": "^1.9.1",
         "web3-eth-abi": "^1.3.4"
@@ -261,6 +262,22 @@
       "version": "0.4.0",
       "resolved": "https://registry.npm.taobao.org/asynckit/download/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/basic-auth/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/big.js": {
       "version": "5.2.2",
@@ -1120,6 +1137,42 @@
       "resolved": "https://registry.npm.taobao.org/minimalistic-crypto-utils/download/minimalistic-crypto-utils-1.0.1.tgz",
       "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
     },
+    "node_modules/morgan": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
+      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+      "dependencies": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/morgan/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/morgan/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/morgan/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.1.2.tgz?cache=0&sync_timestamp=1607433912031&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.1.2.tgz",
@@ -1221,6 +1274,14 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
       "engines": {
         "node": ">= 0.8"
       }
@@ -1968,6 +2029,21 @@
       "resolved": "https://registry.npm.taobao.org/asynckit/download/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
+    "basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
+    },
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npm.taobao.org/big.js/download/big.js-5.2.2.tgz",
@@ -2713,6 +2789,38 @@
       "resolved": "https://registry.npm.taobao.org/minimalistic-crypto-utils/download/minimalistic-crypto-utils-1.0.1.tgz",
       "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
     },
+    "morgan": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
+      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+      "requires": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.1.2.tgz?cache=0&sync_timestamp=1607433912031&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.1.2.tgz",
@@ -2800,6 +2908,11 @@
       "requires": {
         "ee-first": "1.1.1"
       }
+    },
+    "on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
     },
     "once": {
       "version": "1.4.0",

--- a/event-indexer/package-lock.json
+++ b/event-indexer/package-lock.json
@@ -16,6 +16,7 @@
         "jayson": "^3.4.4",
         "js-conflux-sdk": "^1.5.13",
         "mysql2": "^2.2.5",
+        "underscore": "^1.9.1",
         "web3-eth-abi": "^1.3.4"
       }
     },

--- a/event-indexer/package.json
+++ b/event-indexer/package.json
@@ -17,6 +17,7 @@
     "jayson": "^3.4.4",
     "js-conflux-sdk": "^1.5.13",
     "mysql2": "^2.2.5",
+    "underscore": "^1.9.1",
     "web3-eth-abi": "^1.3.4"
   }
 }

--- a/event-indexer/package.json
+++ b/event-indexer/package.json
@@ -16,6 +16,7 @@
     "eth-ens-namehash": "^2.0.8",
     "jayson": "^3.4.4",
     "js-conflux-sdk": "^1.5.13",
+    "morgan": "^1.10.0",
     "mysql2": "^2.2.5",
     "underscore": "^1.9.1",
     "web3-eth-abi": "^1.3.4"

--- a/event-indexer/src/events.js
+++ b/event-indexer/src/events.js
@@ -7,7 +7,7 @@ const snooze = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 class Events {
     constructor(conflux, name, address, topics, startEpoch) {
-        this.conflux = conflux,
+        this.conflux = conflux;
         this.name = name;
         this.address = address;
         this.topics = topics;
@@ -48,7 +48,7 @@ class Events {
                 continue;
             }
 
-            console.log(`[${this.name}] filtering ${fromEpoch}..${toEpoch}...`.grey);
+            // console.log(`[${this.name}] filtering ${fromEpoch}..${toEpoch}...`.grey);
 
             const logs = await this.conflux.getLogs({
                 address: this.address,

--- a/event-indexer/src/index.js
+++ b/event-indexer/src/index.js
@@ -4,6 +4,7 @@ const { Conflux, format } = require('js-conflux-sdk');
 const fs = require('fs');
 const jayson = require('jayson/promise');
 const cors = require('cors');
+const morgan = require('morgan');
 const connect = require('connect');
 const jsonParser = require('body-parser').json;
 const namehash = require('eth-ens-namehash').hash;
@@ -258,6 +259,8 @@ function startServer(db, port) {
         }
     });
 
+    morgan.token('body', (req, res) => JSON.stringify(req.body));
+    app.use(morgan(':method :url :status :response-time ms - :res[content-length] :body - :req[content-length]'));
     app.use(cors({methods: ['POST']}));
     app.use(jsonParser());
     app.use(server.middleware());

--- a/event-indexer/src/index.js
+++ b/event-indexer/src/index.js
@@ -1,3 +1,4 @@
+const assert = require('assert');
 const _colors = require('colors');
 const { Conflux, format } = require('js-conflux-sdk');
 const fs = require('fs');
@@ -10,6 +11,7 @@ const Web3EthAbi = require('web3-eth-abi');
 
 const Events = require('./events');
 const Database = require('./database');
+const Network = require('./network');
 
 const ENS_ADDRESS = '0x87E87fA4b4402DfD641fd67dF7248C673Db31db1';
 const DAO_FACTORY_ADDRESS = '0x855d897dad267A8646e4c92bB3D75FdCc40F314F';
@@ -19,6 +21,25 @@ const START_EPOCH = 20000000;
 const NODE_URL = 'ws://test.confluxrpc.org/ws/v2';
 const conflux = new Conflux({ url: NODE_URL, networkId: 1 });
 conflux.provider.setMaxListeners(0); // suppress warning
+
+const network = new Network(conflux);
+
+function printStats(prev, interval, lastTen) {
+    const current = network.numRequests;
+    const addition = current - prev;
+
+    lastTen.shift();
+    lastTen.push(addition);
+    assert(lastTen.length == 60);
+
+    const sum = lastTen.reduce((a, b) => a + b, 0);
+    const avg = sum / 60;
+
+    console.log(`sent = ${current} (+${addition}), average (/s) = ${avg}`);
+    setTimeout(() => printStats(current, interval, lastTen), interval);
+}
+
+printStats(0, 1000, new Array(60).fill(0));
 
 const ABIS = {
     ENS: JSON.parse(fs.readFileSync('abis/ENS.abi')),
@@ -103,7 +124,7 @@ async function lookupAragonPM(ens) {
 
 // find repo `name` in `apm` starting from epoch `from`
 async function findRepo(apm, name, from) {
-    const events = new Events(conflux, 'main', apm, [EVENTS.NewRepo.sig], from);
+    const events = new Events(network, 'main', apm, [EVENTS.NewRepo.sig], from);
 
     try {
         for await (const [_, logs] of events.get()) {
@@ -186,7 +207,7 @@ async function handleLog(db, context, log) {
 
 // track contract `name` at address `address` from epoch `from`.
 // if the contract is already present in DB, we will continue from the stored epoch.
-async function track(db, name, address, from) {
+async function track(db, name, address, from, untilEpoch = Number.MAX_SAFE_INTEGER) {
     if (RUNNING.has(name)) {
         return;
     }
@@ -195,7 +216,7 @@ async function track(db, name, address, from) {
     console.log(`[${name}] starting from ${from}...`);
     RUNNING.add(name);
 
-    const events = new Events(conflux, name, address, [], from);
+    const events = new Events(network, name, address, [], from);
 
     while (true) {
         try {
@@ -211,8 +232,13 @@ async function track(db, name, address, from) {
 
                 // store epoch logs in db
                 // even with no logs, we periodically commit progress
-                if (logs.length > 0 || epoch % 10000 == 0) {
+                if (logs.length > 0 || epoch % 10000 == 0 || epoch === untilEpoch) {
                     db.storeEpochLogs(epoch, address, logs);
+                }
+
+                if (epoch === untilEpoch) {
+                    console.error(`[${name}] reached epoch ${untilEpoch}, finishing`.bold.white);
+                    return;
                 }
             }
         }

--- a/event-indexer/src/network.js
+++ b/event-indexer/src/network.js
@@ -1,0 +1,128 @@
+const _ = require('underscore');
+const { format } = require('js-conflux-sdk');
+
+class Network {
+    constructor(conflux, batchSize = 200, requestPeriodMs = 1000) {
+        this.conflux = conflux;
+        this.batchSize = batchSize;
+        this.requestPeriodMs = requestPeriodMs;
+
+        // unique ID for each getLogs query received
+        this.id = 0;
+
+        // number of actual requests sent to Conflux node
+        this.numRequests = 0;
+
+        // id => { args, resolve }
+        this.requests = {};
+
+        // periodically make batched get logs requests
+        setInterval(this.requestLogs.bind(this), this.requestPeriodMs);
+
+        // epoch numbers
+        this.latestCheckpoint = 0;
+        this.latestConfirmed = 0;
+        this.latestState = 0;
+        this.latestMined = 0;
+
+        // periodically make epoch requests
+        setInterval(async () => {
+            await this.requestEpochs();
+        }, this.requestPeriodMs);
+    }
+
+    async requestEpochs() {
+        const status = await this.conflux.getStatus();
+        this.numRequests += 1;
+
+        this.latestCheckpoint = status.latestCheckpoint;
+        this.latestConfirmed = status.latestConfirmed;
+        this.latestState = status.latestState;
+        this.latestMined = status.epochNumber;
+    }
+
+    getLogs(args) {
+        const id = this.id;
+        this.id += 1;
+
+        return new Promise((resolve, reject) => {
+            this.requests[id] = { args, resolve };
+
+            // timeout after 10s
+            setTimeout(() => {
+                if (id in this.requests) {
+                    console.error(`Timeout for query ${id} with arguments ${JSON.stringify(args)}`);
+                    reject();
+                }
+            }, 10000);
+        });
+    }
+
+    async getEpochNumber(args) {
+        switch (args) {
+            case 'latest_checkpoint': return this.latestCheckpoint;
+            case 'latest_confirmed': return this.latestConfirmed;
+            case 'latest_state': return this.latestState;
+            case 'latest_mined': return this.latestMined;
+            default: throw `Unsupported getEpochNumber argument: ${args}`;
+        }
+    }
+
+    requestLogs() {
+        // group requests based on `fromEpoch`, `toEpoch`, and `topics`
+        const requestGroups = _.groupBy(this.requests, (req) => [req.args.fromEpoch, req.args.toEpoch, req.args.topics]);
+        this.requests = {}
+
+        for (const group of Object.values(requestGroups)) {
+            // these are the same for all items in `group`
+            const fromEpoch = group[0].args.fromEpoch;
+            const toEpoch = group[0].args.toEpoch;
+            const topics = group[0].args.topics;
+
+            // process groups in batches if there are too many
+            for (const subgroup of _.chunk(group, this.batchSize)) {
+                // collect addresses
+                const addresses = subgroup.map(i => i.args.address);
+
+                // address => resolve
+                const resolve = {};
+
+                for (const item of subgroup) {
+                    resolve[item.args.address.toLowerCase()] = item.resolve;
+                }
+
+                // perform request
+                console.log(`sending request: epochs ${fromEpoch}..${toEpoch} with topics '${topics}' (${addresses.length} addresses)`);
+
+                const p = this.conflux.getLogs({
+                    address: addresses,
+                    topics,
+                    fromEpoch,
+                    toEpoch,
+                });
+
+                this.numRequests += 1;
+
+                p.then((response) => {
+                    // group response items by address
+                    const responseGroups = _.groupBy(response, (resp) => resp.address);
+
+                    // yield each group to the corresponding client
+                    for (const group of Object.values(responseGroups)) {
+                        const address = format.hexAddress(group[0].address).toLowerCase();
+                        resolve[address](group);
+                        delete resolve[address];
+                    }
+
+                    // resolve all the remaining (no logs)
+                    for (const address of Object.keys(resolve)) {
+                        resolve[address]([]);
+                        delete resolve[address];
+                    }
+                })
+            }
+        }
+    }
+}
+
+module.exports = Network;


### PR DESCRIPTION
Instead of sending individual `cfx_getLogs` requests for each contract that we're tracking, we try to combine similar queries into a single query. On our current deployment, this reduces the request load from about 800 requests per second to 4 requests per second.