### PR TITLE
Separate indexer from server

### DIFF
--- a/event-indexer/README.md
+++ b/event-indexer/README.md
@@ -24,3 +24,9 @@ Then, run the indexer:
 ```
 $ node src/index.js
 ```
+
+Finally, run the server to serve `cfx_getLogs` queries.
+
+```
+$ node src/server.js
+```

--- a/event-indexer/src/index.js
+++ b/event-indexer/src/index.js
@@ -2,11 +2,6 @@ const assert = require('assert');
 const _colors = require('colors');
 const { Conflux, format } = require('js-conflux-sdk');
 const fs = require('fs');
-const jayson = require('jayson/promise');
-const cors = require('cors');
-const morgan = require('morgan');
-const express = require('express');
-const jsonParser = require('body-parser').json;
 const namehash = require('eth-ens-namehash').hash;
 const Web3EthAbi = require('web3-eth-abi');
 
@@ -250,28 +245,6 @@ async function track(db, name, address, from, untilEpoch = Number.MAX_SAFE_INTEG
     }
 }
 
-function startServer(db, port) {
-    const app = express();
-
-    const server = jayson.server({
-        cfx_getLogs: async function(args) {
-            return await db.getLogs(args[0]);
-        }
-    });
-
-    morgan.token('body', (req, res) => JSON.stringify(req.body));
-    app.use(morgan(':method :url :status :response-time ms - :res[content-length] :body - :req[content-length]'));
-
-    // enable CORS including pre-flight requests
-    app.options('*', cors());
-    app.use(cors());
-
-    app.use(jsonParser());
-    app.use(server.middleware());
-
-    app.listen(port);
-}
-
 async function main() {
     // init db
     const db = new Database();
@@ -311,10 +284,6 @@ async function main() {
     for (const entry of entries) {
         track(db, entry.name, entry.address, entry.latest + 1);
     }
-
-    // start RPC server
-    startServer(db, 3000);
 }
 
 main();
-

--- a/event-indexer/src/network.js
+++ b/event-indexer/src/network.js
@@ -86,47 +86,47 @@ class Network {
 
             // process groups in batches if there are too many
             for (const subgroup of _.chunk(group, this.batchSize)) {
-                setImmediate(() => {
-                    // collect addresses
-                    const addresses = subgroup.map(i => i.args.address);
+                // TODO: try using setImmediate to avoid blocking the event loop
 
-                    // address => resolve
-                    const resolve = {};
+                // collect addresses
+                const addresses = subgroup.map(i => i.args.address);
 
-                    for (const item of subgroup) {
-                        resolve[item.args.address.toLowerCase()] = item.resolve;
+                // address => resolve
+                const resolve = {};
+
+                for (const item of subgroup) {
+                    resolve[item.args.address.toLowerCase()] = item.resolve;
+                }
+
+                // perform request
+                console.log(`sending request: epochs ${fromEpoch}..${toEpoch} with topics '${topics}' (${addresses.length} addresses)`);
+
+                const p = this.conflux.getLogs({
+                    address: addresses,
+                    topics,
+                    fromEpoch,
+                    toEpoch,
+                });
+
+                this.numRequests += 1;
+
+                p.then((response) => {
+                    // group response items by address
+                    const responseGroups = _.groupBy(response, (resp) => resp.address);
+
+                    // yield each group to the corresponding client
+                    for (const group of Object.values(responseGroups)) {
+                        const address = format.hexAddress(group[0].address).toLowerCase();
+                        resolve[address](group);
+                        delete resolve[address];
                     }
 
-                    // perform request
-                    console.log(`sending request: epochs ${fromEpoch}..${toEpoch} with topics '${topics}' (${addresses.length} addresses)`);
-
-                    const p = this.conflux.getLogs({
-                        address: addresses,
-                        topics,
-                        fromEpoch,
-                        toEpoch,
-                    });
-
-                    this.numRequests += 1;
-
-                    p.then((response) => {
-                        // group response items by address
-                        const responseGroups = _.groupBy(response, (resp) => resp.address);
-
-                        // yield each group to the corresponding client
-                        for (const group of Object.values(responseGroups)) {
-                            const address = format.hexAddress(group[0].address).toLowerCase();
-                            resolve[address](group);
-                            delete resolve[address];
-                        }
-
-                        // resolve all the remaining (no logs)
-                        for (const address of Object.keys(resolve)) {
-                            resolve[address]([]);
-                            delete resolve[address];
-                        }
-                    })
-                });
+                    // resolve all the remaining (no logs)
+                    for (const address of Object.keys(resolve)) {
+                        resolve[address]([]);
+                        delete resolve[address];
+                    }
+                })
             }
         }
     }

--- a/event-indexer/src/server.js
+++ b/event-indexer/src/server.js
@@ -53,7 +53,7 @@ async function main() {
         'port': 3306,
         'user': 'user',
         'password': 'password',
-        'database': 'db2',
+        'database': 'db',
     });
 
     // make sure to close db on exit

--- a/event-indexer/src/server.js
+++ b/event-indexer/src/server.js
@@ -1,0 +1,57 @@
+const _colors = require('colors');
+const jayson = require('jayson/promise');
+const cors = require('cors');
+const morgan = require('morgan');
+const express = require('express');
+const jsonParser = require('body-parser').json;
+
+const Database = require('./database');
+
+function startServer(db, port) {
+    const app = express();
+
+    const server = jayson.server({
+        cfx_getLogs: async function(args) {
+            return await db.getLogs(args[0]);
+        }
+    });
+
+    morgan.token('body', (req, res) => JSON.stringify(req.body));
+    app.use(morgan(':method :url :status :response-time ms - :res[content-length] :body - :req[content-length]'));
+
+    // enable CORS including pre-flight requests
+    app.options('*', cors());
+    app.use(cors());
+
+    app.use(jsonParser());
+    app.use(server.middleware());
+
+    app.listen(port);
+}
+
+async function main() {
+    // init db
+    const db = new Database();
+
+    await db.init({
+        'host': '127.0.0.1',
+        'port': 3306,
+        'user': 'user',
+        'password': 'password',
+        'database': 'db2',
+    });
+
+    // make sure to close db on exit
+    process.stdin.resume();
+    process.on('exit', async () => { db.close(); process.exit(); });
+    process.on('SIGINT', async () => { db.close(); process.exit(); });
+    process.on('SIGUSR1', async () => { db.close(); process.exit(); });
+    process.on('SIGUSR2', async () => { db.close(); process.exit(); });
+    process.on('uncaughtException', async (r) => { console.error(r); db.close(); process.exit(); });
+
+    // start RPC server
+    startServer(db, 3000);
+}
+
+main();
+


### PR DESCRIPTION
Previously, the JSON-RPC server and the indexer ran in the same process. As node.js is single-threaded, the indexer would often prevent the server from serving requests. This is probably the root cause behind the CORS failures we've been experiencing (some CORS pre-flight OPTION requests time out).